### PR TITLE
fix(ci): resolve Lighthouse configuration file path issue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,17 +196,7 @@ jobs:
         uses: treosh/lighthouse-ci-action@v11
         with:
           urls: 'http://localhost:4173'
-          configPath: |
-            {
-              "ci": {
-                "assert": {
-                  "assertions": {
-                    "categories:accessibility": ["error", {"minScore": ${{ env.LIGHTHOUSE_MIN_A11Y }}}],
-                    "categories:performance": ["warn", {"minScore": 0.90}]
-                  }
-                }
-              }
-            }
+          configPath: .lighthouserc.json
           uploadArtifacts: true
           runs: 1
 

--- a/.lighthouserc.json
+++ b/.lighthouserc.json
@@ -3,7 +3,7 @@
     "assert": {
       "assertions": {
         "categories:accessibility": ["error", { "minScore": 0.95 }],
-        "categories:performance": ["warn", { "minScore": 0.90 }]
+        "categories:performance": ["warn", { "minScore": 0.9 }]
       }
     }
   }

--- a/.lighthouserc.json
+++ b/.lighthouserc.json
@@ -2,7 +2,8 @@
   "ci": {
     "assert": {
       "assertions": {
-        "categories:accessibility": ["warn", { "minScore": 0.95 }]
+        "categories:accessibility": ["error", { "minScore": 0.95 }],
+        "categories:performance": ["warn", { "minScore": 0.90 }]
       }
     }
   }


### PR DESCRIPTION
## Problem
The CI workflow was failing due to a Lighthouse configuration issue:
- Error: `ENOENT: no such file or directory`
- Root cause: Inline JSON config instead of file reference

## Solution
- Updated `.lighthouserc.json` to match workflow requirements
- Changed accessibility assertion from 'warn' to 'error'
- Added performance assertion with 0.90 minScore
- Replaced inline JSON config with `.lighthouserc.json` reference

## Changes
- `.lighthouserc.json`: Updated assertions to match CI requirements
- `.github/workflows/ci.yml`: Simplified configPath to reference file

## Testing
- [x] JSON syntax validation passed
- [ ] CI workflow passes (6/6 workflows green)
- [ ] Lighthouse accessibility gate works correctly

Resolves #41